### PR TITLE
fix #5 Premier jour de semaine et numéro de semaine incorrects

### DIFF
--- a/administrator/language/fr-FR/langmetadata.xml
+++ b/administrator/language/fr-FR/langmetadata.xml
@@ -15,7 +15,7 @@
 		<tag>fr-FR</tag>
 		<rtl>0</rtl>
 		<locale>fr_FR.utf8, fr_FR.UTF-8, fr_FR, fr, français, french-fr, france, francophone</locale>
-		<firstDay>0</firstDay>
+		<firstDay>1</firstDay>
 		<weekEnd>0,6</weekEnd>
 		<calendar>gregorian</calendar>
 	</metadata>

--- a/api/language/fr-FR/langmetadata.xml
+++ b/api/language/fr-FR/langmetadata.xml
@@ -15,7 +15,7 @@
 		<tag>fr-FR</tag>
 		<rtl>0</rtl>
 		<locale>fr_FR.utf8, fr_FR.UTF-8, fr_FR, fr, français, french-fr, france, francophone</locale>
-		<firstDay>0</firstDay>
+		<firstDay>1</firstDay>
 		<weekEnd>0,6</weekEnd>
 		<calendar>gregorian</calendar>
 	</metadata>

--- a/language/fr-FR/langmetadata.xml
+++ b/language/fr-FR/langmetadata.xml
@@ -13,7 +13,7 @@
 		<name>French (fr-FR)</name>
 		<nativeName>French (fr-FR)</nativeName>
 		<tag>fr-FR</tag>
-		<rtl>0</rtl>
+		<rtl>1</rtl>
 		<locale>fr_FR.utf8, fr_FR.UTF-8, fr_FR, fr, français, french-fr, france, francophone</locale>
 		<firstDay>0</firstDay>
 		<weekEnd>0,6</weekEnd>


### PR DESCRIPTION
Pull Request pour l'Issue #5 .

### Résumé des modifications
Modification du premier jour de la semaine. Le premier de la semaine est Lundi en France.


### Où le texte de langue sera-t-il affiché / Comment peut-il être testé
Afficher un calendrier dans joomla par exemple dans l'administration, ajout d'un article et date de publication.

**Avant la correction**
![image](https://github.com/user-attachments/assets/2089fe85-6d36-4c4b-9d96-a94a07af4786)

**Après la correction**
![image](https://github.com/user-attachments/assets/e9c1352f-8e8d-44e7-b6ab-a03045f0c64b)
